### PR TITLE
Custom Trait and Skill updating

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ dependencies {
     deobfCompile "CraftTweaker2:CraftTweaker2-MC1120-Main:1.12-${crafttweaker_version}"
     deobfCompile "CraftTweaker2:CraftTweaker2-API:1.12-${crafttweaker_version}"
     deobfCompile "CraftTweaker2:ZenScript:1.12-${crafttweaker_version}"
-    deobfCompile "codersafterdark.reskillable:Reskillable:1.12.2-1.3.0-SNAPSHOT.40"
+    deobfCompile "codersafterdark.reskillable:Reskillable:1.12.2-1.3.0-PR-91.1"
     deobfCompile "com.wayoftime.bloodmagic:BloodMagic:1.12.2-2.2.11-96"
     deobfCompile "com.azanor.baubles:Baubles:1.12-1.5.2"
     deobfCompile "mcjty.theoneprobe:TheOneProbe-1.12:1.12-1.4.22-13"

--- a/src/main/java/codersafterdark/compatskills/common/compats/minecraft/MinecraftCompatHandler.java
+++ b/src/main/java/codersafterdark/compatskills/common/compats/minecraft/MinecraftCompatHandler.java
@@ -1,14 +1,34 @@
 package codersafterdark.compatskills.common.compats.minecraft;
 
+import codersafterdark.compatskills.common.compats.minecraft.dimension.dimensionlocks.DimensionLockHandler;
+import codersafterdark.compatskills.common.compats.minecraft.dimension.dimensionrequirement.DimensionRequirement;
 import codersafterdark.compatskills.common.compats.minecraft.entity.animaltameevent.AnimalTameEventHandler;
 import codersafterdark.compatskills.common.compats.minecraft.entity.entitymountevent.EntityMountEventHandler;
+import codersafterdark.compatskills.common.invertedrequirements.InvertedDimension;
+import codersafterdark.reskillable.api.ReskillableAPI;
 import net.minecraftforge.common.MinecraftForge;
 
 public class MinecraftCompatHandler {
     public static void setup(){
         AnimalTameEventHandler tameEventHandler = new AnimalTameEventHandler();
         EntityMountEventHandler entityMountEventHandler = new EntityMountEventHandler();
+        DimensionLockHandler dimensionLockHandler = new DimensionLockHandler();
         MinecraftForge.EVENT_BUS.register(tameEventHandler);
         MinecraftForge.EVENT_BUS.register(entityMountEventHandler);
+        MinecraftForge.EVENT_BUS.register(dimensionLockHandler);
+        ReskillableAPI.getInstance().getRequirementRegistry().addRequirementHandler("dim", input -> {
+            try {
+                return new DimensionRequirement(Integer.parseInt(input));
+            } catch (NumberFormatException ignored) {
+            }
+            return null;
+        });
+        ReskillableAPI.getInstance().getRequirementRegistry().addRequirementHandler("!dim", input -> {
+            try {
+                return new InvertedDimension(Integer.parseInt(input));
+            } catch (NumberFormatException ignored) {
+            }
+            return null;
+        });
     }
 }

--- a/src/main/java/codersafterdark/compatskills/common/compats/minecraft/dimension/dimensionlocks/DimensionLockKey.java
+++ b/src/main/java/codersafterdark/compatskills/common/compats/minecraft/dimension/dimensionlocks/DimensionLockKey.java
@@ -2,6 +2,8 @@ package codersafterdark.compatskills.common.compats.minecraft.dimension.dimensio
 
 import codersafterdark.reskillable.api.data.LockKey;
 
+import java.util.Objects;
+
 public class DimensionLockKey implements LockKey {
     private final int dimension;
 
@@ -16,6 +18,6 @@ public class DimensionLockKey implements LockKey {
 
     @Override
     public int hashCode() {
-        return dimension;
+        return Objects.hashCode(dimension);
     }
 }

--- a/src/main/java/codersafterdark/compatskills/common/compats/minecraft/dimension/dimensionlocks/DimensionLockTweaker.java
+++ b/src/main/java/codersafterdark/compatskills/common/compats/minecraft/dimension/dimensionlocks/DimensionLockTweaker.java
@@ -21,7 +21,7 @@ public class DimensionLockTweaker {
         private final int dimension;
         private final String[] requirements;
 
-        AddDimensionLock(int dimension, String... requirements){
+        private AddDimensionLock(int dimension, String... requirements){
             this.dimension = dimension;
             this.requirements = requirements;
         }
@@ -39,7 +39,7 @@ public class DimensionLockTweaker {
             for (String string : requirements) {
                 descString.append(string).append(", ");
             }
-            return "Added Dimension Lock for Dimension: " + dimension + ", With Requirements: " + descString;
+            return "Added Dimension Lock for Dimension: " + dimension + ", With " + descString;
         }
     }
 }

--- a/src/main/java/codersafterdark/compatskills/common/compats/minecraft/dimension/dimensionrequirement/DimensionRequirement.java
+++ b/src/main/java/codersafterdark/compatskills/common/compats/minecraft/dimension/dimensionrequirement/DimensionRequirement.java
@@ -33,6 +33,6 @@ public class DimensionRequirement extends Requirement {
 
     @Override
     public RequirementComparision matches(Requirement other) {
-        return other instanceof DimensionRequirement && dimension == (((DimensionRequirement) other).dimension) ? RequirementComparision.EQUAL_TO : RequirementComparision.NOT_EQUAL;
+        return other instanceof DimensionRequirement && dimension == ((DimensionRequirement) other).dimension ? RequirementComparision.EQUAL_TO : RequirementComparision.NOT_EQUAL;
     }
 }

--- a/src/main/java/codersafterdark/compatskills/common/compats/minecraft/entity/EntityLockKey.java
+++ b/src/main/java/codersafterdark/compatskills/common/compats/minecraft/entity/EntityLockKey.java
@@ -2,21 +2,33 @@ package codersafterdark.compatskills.common.compats.minecraft.entity;
 
 import codersafterdark.reskillable.api.data.LockKey;
 import net.minecraft.entity.Entity;
+import net.minecraftforge.fml.common.registry.EntityEntry;
+import net.minecraftforge.fml.common.registry.ForgeRegistries;
 
-public class EntityLockKey implements LockKey {
-    private final Entity entity;
+public abstract class EntityLockKey implements LockKey {
+    private final String entityID;
 
-    public EntityLockKey (Entity entity) {
-        this.entity = entity;
+    protected EntityLockKey (String entityID) {
+        this.entityID = entityID == null ? "" : entityID;
+    }
+
+    //returns no_registry_name like CraftTweaker does so that it can be marked as equal
+    protected static String getEntityID(Entity entity) {
+        for (EntityEntry entry: ForgeRegistries.ENTITIES.getValuesCollection()) {
+            if (entry.getEntityClass() == entity.getClass()) {
+                return entry.getRegistryName() != null ? entry.getRegistryName().toString() : "no_registry_name";
+            }
+        }
+        return "no_registry_name";
     }
 
     @Override
     public boolean equals(Object obj) {
-        return obj == this || obj instanceof EntityLockKey && entity == ((EntityLockKey) obj).entity;
+        return obj == this || obj instanceof EntityLockKey && entityID.equals(((EntityLockKey) obj).entityID);
     }
 
     @Override
     public int hashCode() {
-        return entity.hashCode();
+        return entityID.hashCode();
     }
 }

--- a/src/main/java/codersafterdark/compatskills/common/compats/minecraft/entity/animaltameevent/AnimalTameEventHandler.java
+++ b/src/main/java/codersafterdark/compatskills/common/compats/minecraft/entity/animaltameevent/AnimalTameEventHandler.java
@@ -1,13 +1,11 @@
 package codersafterdark.compatskills.common.compats.minecraft.entity.animaltameevent;
 
-import codersafterdark.compatskills.common.compats.minecraft.entity.EntityLockKey;
 import codersafterdark.reskillable.api.data.PlayerData;
 import codersafterdark.reskillable.api.data.PlayerDataHandler;
 import codersafterdark.reskillable.api.data.RequirementHolder;
 import codersafterdark.reskillable.api.requirement.Requirement;
 import codersafterdark.reskillable.base.LevelLockHandler;
 import net.minecraft.client.resources.I18n;
-import net.minecraft.entity.passive.EntityAnimal;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TextComponentString;
@@ -19,10 +17,12 @@ import java.util.List;
 public class AnimalTameEventHandler {
     @SubscribeEvent
     public void onTame(AnimalTameEvent event) {
+        if (event.isCanceled()) {
+            return;
+        }
         EntityPlayer player = event.getTamer();
-        EntityAnimal animal = event.getAnimal();
         PlayerData data = PlayerDataHandler.get(player);
-        RequirementHolder requirementHolder = LevelLockHandler.getLockByKey(new EntityLockKey(animal));
+        RequirementHolder requirementHolder = LevelLockHandler.getLockByKey(new EntityTameKey(event.getAnimal()));
         if (requirementHolder != null && !requirementHolder.equals(LevelLockHandler.EMPTY_LOCK) && !data.matchStats(requirementHolder)) {
             event.setCanceled(true);
             String error = I18n.format("compatskills.entity.entityTameError");

--- a/src/main/java/codersafterdark/compatskills/common/compats/minecraft/entity/animaltameevent/AnimalTameEventTweaker.java
+++ b/src/main/java/codersafterdark/compatskills/common/compats/minecraft/entity/animaltameevent/AnimalTameEventTweaker.java
@@ -1,14 +1,12 @@
 package codersafterdark.compatskills.common.compats.minecraft.entity.animaltameevent;
 
 import codersafterdark.compatskills.CompatSkills;
-import codersafterdark.compatskills.common.compats.minecraft.entity.EntityLockKey;
 import codersafterdark.compatskills.utils.CheckMethods;
 import codersafterdark.reskillable.api.data.RequirementHolder;
 import codersafterdark.reskillable.base.LevelLockHandler;
 import crafttweaker.IAction;
 import crafttweaker.annotations.ZenRegister;
-import crafttweaker.api.entity.IEntity;
-import crafttweaker.api.minecraft.CraftTweakerMC;
+import crafttweaker.api.entity.IEntityDefinition;
 import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
 
@@ -16,24 +14,25 @@ import stanhebben.zenscript.annotations.ZenMethod;
 @ZenRegister
 public class AnimalTameEventTweaker {
     @ZenMethod
-    public static void addTameLock(IEntity entity, String... defaultRequirements){
-        CompatSkills.LATE_ADDITIONS.add(new AddTameLock(entity, defaultRequirements));
+    public static void addTameLock(IEntityDefinition definition, String... defaultRequirements){
+        CompatSkills.LATE_ADDITIONS.add(new AddTameLock(definition, defaultRequirements));
     }
 
     private static class AddTameLock implements IAction {
-        private final IEntity entity;
+        private final IEntityDefinition definition;
         private final String[] requirements;
 
-        AddTameLock(IEntity entity, String... requirements){
-            this.entity = entity;
+        private AddTameLock(IEntityDefinition definition, String... requirements){
+            this.definition = definition;
             this.requirements = requirements;
         }
 
 
         @Override
         public void apply() {
-            if (CheckMethods.checkValidIEntity(entity) & CheckMethods.checkStringArray(requirements)){
-                LevelLockHandler.addLockByKey(new EntityLockKey(CraftTweakerMC.getEntity(entity)), RequirementHolder.fromStringList(requirements));
+            if (CheckMethods.checkValidIEntityDefinition(definition) & CheckMethods.checkStringArray(requirements)) {
+                definition.getInternal();
+                LevelLockHandler.addLockByKey(new EntityTameKey(definition.getId()), RequirementHolder.fromStringList(requirements));
             }
         }
 
@@ -43,7 +42,7 @@ public class AnimalTameEventTweaker {
             for (String string : requirements) {
                 descString.append(string).append(", ");
             }
-            return "Added Entity Tame Lock for Entity: " + entity.getDisplayName() + ", With Requirements: " + descString;
+            return "Added Entity Tame Lock for Entity: " + (definition == null ? "null" : definition.getName()) + ", With " + descString;
         }
     }
 }

--- a/src/main/java/codersafterdark/compatskills/common/compats/minecraft/entity/animaltameevent/EntityTameKey.java
+++ b/src/main/java/codersafterdark/compatskills/common/compats/minecraft/entity/animaltameevent/EntityTameKey.java
@@ -1,0 +1,19 @@
+package codersafterdark.compatskills.common.compats.minecraft.entity.animaltameevent;
+
+import codersafterdark.compatskills.common.compats.minecraft.entity.EntityLockKey;
+import net.minecraft.entity.Entity;
+
+public class EntityTameKey extends EntityLockKey {
+    public EntityTameKey(String entityID) {
+        super(entityID);
+    }
+
+    public EntityTameKey(Entity entity) {
+        this(getEntityID(entity));
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return super.equals(obj) && obj instanceof EntityTameKey;
+    }
+}

--- a/src/main/java/codersafterdark/compatskills/common/compats/minecraft/entity/entitymountevent/EntityMountEventHandler.java
+++ b/src/main/java/codersafterdark/compatskills/common/compats/minecraft/entity/entitymountevent/EntityMountEventHandler.java
@@ -1,13 +1,11 @@
 package codersafterdark.compatskills.common.compats.minecraft.entity.entitymountevent;
 
-import codersafterdark.compatskills.common.compats.minecraft.entity.EntityLockKey;
 import codersafterdark.reskillable.api.data.PlayerData;
 import codersafterdark.reskillable.api.data.PlayerDataHandler;
 import codersafterdark.reskillable.api.data.RequirementHolder;
 import codersafterdark.reskillable.api.requirement.Requirement;
 import codersafterdark.reskillable.base.LevelLockHandler;
 import net.minecraft.client.resources.I18n;
-import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TextComponentString;
@@ -18,19 +16,14 @@ import java.util.List;
 
 public class EntityMountEventHandler {
     @SubscribeEvent
-    public void onMount(EntityMountEvent event){
-        EntityPlayer player = null;
-        PlayerData data = null;
-        RequirementHolder requirementHolder = null;
-        Entity entity = event.getEntityBeingMounted();
-        if (event.getEntityMounting() instanceof EntityPlayer){
-            player = (EntityPlayer) event.getEntityMounting();
-            data = PlayerDataHandler.get(player);
+    public void onMount(EntityMountEvent event) {
+        if (event.isCanceled() || event.isDismounting() || !(event.getEntityMounting() instanceof EntityPlayer)) {
+            return;
         }
-        if (player != null && data != null){
-            requirementHolder = LevelLockHandler.getLockByKey(new EntityLockKey(entity));
-        }
-        if (requirementHolder != null && requirementHolder.equals(LevelLockHandler.EMPTY_LOCK) && !data.matchStats(requirementHolder)){
+        EntityPlayer player = (EntityPlayer) event.getEntityMounting();
+        PlayerData data = PlayerDataHandler.get(player);
+        RequirementHolder requirementHolder = LevelLockHandler.getLockByKey(new EntityMountKey(event.getEntityBeingMounted()));
+        if (requirementHolder != null && !requirementHolder.equals(LevelLockHandler.EMPTY_LOCK) && !data.matchStats(requirementHolder)) {
             event.setCanceled(true);
             String error = I18n.format("compatskills.entity.entityMountError");
             List<Requirement> requirements = requirementHolder.getRequirements();

--- a/src/main/java/codersafterdark/compatskills/common/compats/minecraft/entity/entitymountevent/EntityMountEventTweaker.java
+++ b/src/main/java/codersafterdark/compatskills/common/compats/minecraft/entity/entitymountevent/EntityMountEventTweaker.java
@@ -1,14 +1,12 @@
 package codersafterdark.compatskills.common.compats.minecraft.entity.entitymountevent;
 
 import codersafterdark.compatskills.CompatSkills;
-import codersafterdark.compatskills.common.compats.minecraft.entity.EntityLockKey;
 import codersafterdark.compatskills.utils.CheckMethods;
 import codersafterdark.reskillable.api.data.RequirementHolder;
 import codersafterdark.reskillable.base.LevelLockHandler;
 import crafttweaker.IAction;
 import crafttweaker.annotations.ZenRegister;
-import crafttweaker.api.entity.IEntity;
-import crafttweaker.api.minecraft.CraftTweakerMC;
+import crafttweaker.api.entity.IEntityDefinition;
 import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
 
@@ -16,23 +14,23 @@ import stanhebben.zenscript.annotations.ZenMethod;
 @ZenRegister
 public class EntityMountEventTweaker {
     @ZenMethod
-    public static void addMountLock(IEntity entity, String... defaultRequirements){
-        CompatSkills.LATE_ADDITIONS.add(new AddMountLock(entity, defaultRequirements));
+    public static void addMountLock(IEntityDefinition definition, String... defaultRequirements){
+        CompatSkills.LATE_ADDITIONS.add(new AddMountLock(definition, defaultRequirements));
     }
 
     private static class AddMountLock implements IAction {
-        private final IEntity entity;
+        private final IEntityDefinition definition;
         private final String[] requirements;
 
-        AddMountLock(IEntity entity, String... requirements){
-            this.entity = entity;
+        private AddMountLock(IEntityDefinition definition, String... requirements){
+            this.definition = definition;
             this.requirements = requirements;
         }
 
         @Override
         public void apply() {
-            if (CheckMethods.checkValidIEntity(entity) & CheckMethods.checkStringArray(requirements)){
-                LevelLockHandler.addLockByKey(new EntityLockKey(CraftTweakerMC.getEntity(entity)), RequirementHolder.fromStringList(requirements));
+            if (CheckMethods.checkValidIEntityDefinition(definition) & CheckMethods.checkStringArray(requirements)){
+                LevelLockHandler.addLockByKey(new EntityMountKey(definition.getId()), RequirementHolder.fromStringList(requirements));
             }
         }
 
@@ -42,7 +40,7 @@ public class EntityMountEventTweaker {
             for (String string : requirements) {
                 descString.append(string).append(", ");
             }
-            return "Added Entity Mount Lock for Entity: " + entity.getDisplayName() + ", With Requirements: " + descString;
+            return "Added Entity Mount Lock for Entity: " + (definition == null ? "null" : definition.getName()) + ", With " + descString;
         }
     }
 }

--- a/src/main/java/codersafterdark/compatskills/common/compats/minecraft/entity/entitymountevent/EntityMountKey.java
+++ b/src/main/java/codersafterdark/compatskills/common/compats/minecraft/entity/entitymountevent/EntityMountKey.java
@@ -1,0 +1,19 @@
+package codersafterdark.compatskills.common.compats.minecraft.entity.entitymountevent;
+
+import codersafterdark.compatskills.common.compats.minecraft.entity.EntityLockKey;
+import net.minecraft.entity.Entity;
+
+public class EntityMountKey extends EntityLockKey {
+    public EntityMountKey(String entityID) {
+        super(entityID);
+    }
+
+    public EntityMountKey(Entity entity) {
+        this(getEntityID(entity));
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return super.equals(obj) && obj instanceof EntityMountKey;
+    }
+}

--- a/src/main/java/codersafterdark/compatskills/common/compats/reskillable/customcontent/CrTSkill.java
+++ b/src/main/java/codersafterdark/compatskills/common/compats/reskillable/customcontent/CrTSkill.java
@@ -1,6 +1,5 @@
 package codersafterdark.compatskills.common.compats.reskillable.customcontent;
 
-
 import codersafterdark.compatskills.utils.CheckMethods;
 import codersafterdark.compatskills.utils.CompatSkillConstants;
 import codersafterdark.reskillable.api.ReskillableRegistries;
@@ -18,18 +17,58 @@ import stanhebben.zenscript.annotations.ZenProperty;
 public class CrTSkill extends Skill {
 
     @ZenProperty
-    public IFormattedText name = null;
+    public IFormattedText name;
+
+    @ZenMethod
+    public void setLevelCap(int cap) {
+        skillConfig.setLevelCap(cap);
+    }
+
+    @ZenMethod
+    public void setEnabled(boolean enabled) {
+        skillConfig.setEnabled(enabled);
+    }
+
+    @ZenMethod
+    public void setSkillPointInterval(int amount) {
+        skillConfig.setSkillPointInterval(amount);
+    }
+
+    @ZenMethod
+    public void setBaseCost(int cost) {
+        skillConfig.setBaseLevelCost(cost);
+    }
+
+    //TODO make a way to set the level staggering
 
     public CrTSkill(ResourceLocation name, ResourceLocation background) {
         super(name, background);
         ReskillableRegistries.SKILLS.register(this);
     }
 
+
+    private static CrTSkill createSkill(ResourceLocation name, ResourceLocation background) {
+        if (ReskillableRegistries.SKILLS.containsKey(name)) {
+            Skill value = ReskillableRegistries.SKILLS.getValue(name);
+            if (value instanceof CrTSkill) {
+                CrTSkill customSkill = (CrTSkill) value;
+                if (!background.equals(customSkill.getBackground())) {
+                    customSkill.background = background;
+                    CraftTweakerAPI.logInfo("Loaded Skill: " + name + " - Updated Background: " + background);
+                } else {
+                    CraftTweakerAPI.logInfo("Loaded Skill: " + name);
+                }
+                return customSkill;
+            }
+        }
+        CraftTweakerAPI.logInfo("Created new Skill: " + name + " - With Background: " + background);
+        return new CrTSkill(name, background);
+    }
+
     @ZenMethod
     public static CrTSkill createSkill(String name, String backGroundLocation) {
         if (CheckMethods.checkString(name) & CheckMethods.checkString(backGroundLocation)) {
-            CraftTweakerAPI.logInfo("Created Skill: " + name + " - With Background: " + backGroundLocation);
-            return new CrTSkill(new ResourceLocation(CompatSkillConstants.MOD_ID, name), new ResourceLocation(backGroundLocation));
+            return createSkill(new ResourceLocation(CompatSkillConstants.MOD_ID, name), new ResourceLocation(backGroundLocation));
         }
         return null;
     }
@@ -37,8 +76,7 @@ public class CrTSkill extends Skill {
     @ZenMethod
     public static CrTSkill createNewSkill(String nameLocation, String backGroundLocation) {
         if (CheckMethods.checkString(nameLocation) & CheckMethods.checkString(backGroundLocation)) {
-            CraftTweakerAPI.logInfo("Created Skill: " + nameLocation + " - With Background: " + backGroundLocation);
-            return new CrTSkill(new ResourceLocation(nameLocation), new ResourceLocation(backGroundLocation));
+            return createSkill(new ResourceLocation(nameLocation), new ResourceLocation(backGroundLocation));
         }
         return null;
     }
@@ -47,4 +85,6 @@ public class CrTSkill extends Skill {
     public String getName() {
         return name == null ? super.getName() : name.getText();
     }
+
+    //TODO override getSpriteFromRank when we figure out a good way to say how many pictures they provide
 }

--- a/src/main/java/codersafterdark/compatskills/common/compats/tinkersconstruct/TinkerLockHandler.java
+++ b/src/main/java/codersafterdark/compatskills/common/compats/tinkersconstruct/TinkerLockHandler.java
@@ -52,7 +52,7 @@ public class TinkerLockHandler {
     public void onToolCrafted(TinkerCraftingEvent.ToolCraftingEvent event) {
         PlayerData data = PlayerDataHandler.get(event.getPlayer());
         if (data == null) {
-            //TODO this event is the one that actually can have data be null
+            event.setCanceled(true);//Support for canceling if old tinkers so that they cant create dupes
             return;
         }
 
@@ -107,7 +107,7 @@ public class TinkerLockHandler {
             return null;
         }
         StringBuilder reqs = new StringBuilder(errorType);
-        reqs.append("\n\nRequirements:");
+        reqs.append("\n\n").append(I18n.format("compatskills.misc.Requirements"));
         for (Requirement req : holder.getRequirements()) {
             reqs.append('\n').append(req.getToolTip(data));
         }

--- a/src/main/java/codersafterdark/compatskills/common/invertedrequirements/InvertedDimension.java
+++ b/src/main/java/codersafterdark/compatskills/common/invertedrequirements/InvertedDimension.java
@@ -29,11 +29,11 @@ public class InvertedDimension extends Requirement {
                 color = TextFormatting.RED;
             }
         }
-        return TextFormatting.GRAY + " - " + TextFormatting.LIGHT_PURPLE + I18n.format("compatskills.misc.dimensionFormat", color, dimension);
+        return TextFormatting.GRAY + " - " + TextFormatting.LIGHT_PURPLE + I18n.format("compatskills.misc.invertedDimensionFormat", color, dimension);
     }
 
     @Override
     public RequirementComparision matches(Requirement other) {
-        return other instanceof InvertedDimension && dimension == (((InvertedDimension) other).dimension) ? RequirementComparision.EQUAL_TO : RequirementComparision.NOT_EQUAL;
+        return other instanceof InvertedDimension && dimension == ((InvertedDimension) other).dimension ? RequirementComparision.EQUAL_TO : RequirementComparision.NOT_EQUAL;
     }
 }

--- a/src/main/java/codersafterdark/compatskills/utils/CheckMethods.java
+++ b/src/main/java/codersafterdark/compatskills/utils/CheckMethods.java
@@ -9,14 +9,11 @@ import com.cout970.magneticraft.api.MagneticraftApi;
 import crafttweaker.CraftTweakerAPI;
 import crafttweaker.api.data.DataMap;
 import crafttweaker.api.data.IData;
-import crafttweaker.api.entity.IEntity;
+import crafttweaker.api.entity.IEntityDefinition;
 import crafttweaker.api.item.IItemStack;
-import crafttweaker.api.minecraft.CraftTweakerMC;
-import net.minecraft.entity.Entity;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.DimensionManager;
 import net.minecraftforge.fml.common.Loader;
-import net.minecraftforge.fml.common.registry.EntityRegistry;
 import slimeknights.tconstruct.library.TinkerRegistry;
 import slimeknights.tconstruct.library.materials.Material;
 import slimeknights.tconstruct.library.modifiers.IModifier;
@@ -92,9 +89,9 @@ public class CheckMethods {
         return true;
     }
 
-    public static boolean checkValidIEntity(IEntity entity) {
+    public static boolean checkValidIEntityDefinition(IEntityDefinition entity) {
         if (entity == null){
-            CraftTweakerAPI.logError("IEntity was found to be null");
+            CraftTweakerAPI.logError("IEntityDefinition was found to be null");
             return false;
         }
         return true;

--- a/src/main/resources/assets/compatskills/lang/en_us.lang
+++ b/src/main/resources/assets/compatskills/lang/en_us.lang
@@ -1,10 +1,12 @@
 # FORMATS
 compatskills.misc.gamestageFormat=GameStage: %s%s
+compatskills.misc.dimensionFormat=Dimension: %s%s
 compatskills.misc.Requirements=Requirements:
 compatskills.misc.Shift=Press Shift to See Requirements
 
 compatskills.misc.requirements.invertedAchievementFormat=!Advancement: %s
 compatskills.misc.requirements.invertedGamestageFormat=!GameStage: %s%s
+compatskills.misc.invertedDimensionFormat=!Dimension: %s%s
 compatskills.misc.requirements.invertedSkillFormat=!%s%s: %s%d
 compatskills.misc.requirements.invertedTraitFormat=!Trait: %s%s
 
@@ -19,3 +21,6 @@ compatskills.bloodmagic.ritualError=As the ritual activates, you don't achieve t
 compatskills.tconstruct.materialError=For every stroke of the hammer, the more the material resists.
 compatskills.tconstruct.modifierError=After many countless moments, you can't figure out how to modify the tool to your desire.
 compatskills.tconstruct.toolTypeError=No matter how the instructions, a novice can not create a master piece.
+
+compatskills.entity.entityMountError=No matter how hard you try you are unable to find your balance, and fall off.
+compatskills.entity.entityTameError=As you attempt to tame the creature it resists you.


### PR DESCRIPTION
Closes #35
Makes it so that Custom Skills and Traits update existing ones with the same name to have the latest values. For example if you change the display name or requirements it will now update.
Added a way to disable custom traits from CraftTweaker
Added methods to Custom Skills to be able to edit their config value properties (level cap, base cost, etc) from CraftTweaker. (Currently no way to set level staggering of skills from CraftTweaker)

Not sure why it is including my last commit about updating taming and riding locks but it doesn't cause merge conflicts so oh well.