### PR TITLE
Made item requirements more generic

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ dependencies {
     deobfCompile "CraftTweaker2:CraftTweaker2-MC1120-Main:1.12-${crafttweaker_version}"
     deobfCompile "CraftTweaker2:CraftTweaker2-API:1.12-${crafttweaker_version}"
     deobfCompile "CraftTweaker2:ZenScript:1.12-${crafttweaker_version}"
-    deobfCompile "codersafterdark.reskillable:Reskillable:1.12.2-1.3.0-SNAPSHOT.43"
+    deobfCompile "codersafterdark.reskillable:Reskillable:1.12.2-1.4.0-SNAPSHOT.53"
     deobfCompile "com.wayoftime.bloodmagic:BloodMagic:1.12.2-2.2.11-96"
     deobfCompile "com.azanor.baubles:Baubles:1.12-1.5.2"
     deobfCompile "mcjty.theoneprobe:TheOneProbe-1.12:1.12-1.4.22-13"

--- a/src/main/java/codersafterdark/compatskills/common/compats/minecraft/item/ItemRequirement.java
+++ b/src/main/java/codersafterdark/compatskills/common/compats/minecraft/item/ItemRequirement.java
@@ -1,51 +1,127 @@
 package codersafterdark.compatskills.common.compats.minecraft.item;
 
-import codersafterdark.reskillable.api.data.PlayerData;
+import codersafterdark.reskillable.api.data.*;
 import codersafterdark.reskillable.api.requirement.Requirement;
 import codersafterdark.reskillable.api.requirement.RequirementComparision;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.util.text.TextFormatting;
 
 public class ItemRequirement extends Requirement {
+    //TODO: maybe make an API endpoint in Reskillable to somehow access the types of things that can be created from ItemStack
+    //TODO cont: in case there are custom ones (like the emc lock in CompatSkills), would need a more generic way of creating requirement
+    private final NBTLockKey key;
 
-    private ItemStack stack;
-
-    public ItemRequirement (ItemStack stack) {
-        this.stack = stack;
+    public ItemRequirement(NBTLockKey key) {
+        this.key = key;
     }
 
     @Override
-    public boolean achievedByPlayer(EntityPlayer entityPlayerMP) {
-        return checkHolding(stack, entityPlayerMP);
+    public boolean achievedByPlayer(EntityPlayer player) {
+        return itemMatches(player.getHeldItemMainhand()) || itemMatches(player.getHeldItemOffhand());
     }
 
     @Override
     public String getToolTip(PlayerData data) {
-        String stackDisplayName = stack.getDisplayName();
-        String toolTip = "";
-        TextFormatting color = TextFormatting.GREEN;
-        if (!achievedByPlayer(data.playerWR.get())){
-            color = TextFormatting.RED;
+        //TODO make the combined information look nicer in the formatting
+        String displayName = "";
+        if (key instanceof ItemInfo) {
+            ItemInfo info = (ItemInfo) key;
+            ItemStack stack = new ItemStack(info.getItem(), 1, info.getMetadata());
+            stack.setTagCompound(key.getTag());//Needed in case the tag has a custom item name stored
+            displayName += stack.getDisplayName();
+        } else if (key instanceof ModLockKey) {
+            displayName += "From Mod: " + ((ModLockKey) key).getModName();
+        }// else if (key instanceof GenericNBTLockKey) //No specific check needed because it just needs to show what the nbt tag must be
+        if (key.getTag() != null) {
+            displayName += " With NBT Tag: " + key.getTag().toString();//Maybe format NBT slightly better
         }
-        if (stack != null){
-            toolTip = TextFormatting.GRAY + " - " + TextFormatting.GRAY + new TextComponentTranslation("compatskills.misc.requirements.itemRequirementFormat", color, stackDisplayName);
-        }
-
-        return toolTip;
+        TextFormatting color = achievedByPlayer(data.playerWR.get()) ? TextFormatting.GREEN : TextFormatting.RED;
+        return TextFormatting.GRAY + " - " + new TextComponentTranslation("compatskills.misc.requirements.itemRequirementFormat", color, displayName.trim()).getUnformattedComponentText();
     }
 
     @Override
-    public RequirementComparision matches(Requirement other) {
-        return other instanceof ItemRequirement && getStack().equals(((ItemRequirement) other).getStack()) ? RequirementComparision.EQUAL_TO : RequirementComparision.NOT_EQUAL;
+    public RequirementComparision matches(Requirement o) {
+        if (o instanceof ItemRequirement) {
+            ItemRequirement other = (ItemRequirement) o;
+            if (key.equals(other.key)) {
+                return RequirementComparision.EQUAL_TO;
+            } else {
+                if (key instanceof ItemInfo) {
+                    if (other.key instanceof ItemInfo) {
+                        if (key.getNotFuzzy().equals(other.key.getNotFuzzy())) {
+                            if (key.fuzzyEquals(other.key)) {
+                                return RequirementComparision.GREATER_THAN;
+                            } else if (other.key.fuzzyEquals(key)) {
+                                return RequirementComparision.LESS_THAN;
+                            }
+                        }
+                    } else if (other.key instanceof ModLockKey) {
+                        ResourceLocation registryName = ((ItemInfo) key).getItem().getRegistryName();
+                        if (registryName != null && registryName.getResourceDomain().equals(((ModLockKey) other.key).getModName()) && key.fuzzyEquals(other.key)) {
+                            //Does not need to check for LESS_THAN because we are at an item level lock compared to a mod level one
+                            return RequirementComparision.GREATER_THAN;
+                        }
+                    } else if (other.key instanceof GenericNBTLockKey && key.fuzzyEquals(other.key)) {
+                        return RequirementComparision.GREATER_THAN;
+                    }
+                } else if (key instanceof ModLockKey) {
+                    if (other.key instanceof ItemInfo) {
+                        ResourceLocation registryName = ((ItemInfo) other.key).getItem().getRegistryName();
+                        if (registryName != null && ((ModLockKey) key).getModName().equals(registryName.getResourceDomain()) && key.fuzzyEquals(other.key)) {
+                            //Does not need to check for GREATER_THAN because we are at a mod level lock compared to an item one
+                            return RequirementComparision.LESS_THAN;
+                        }
+                    } else if (other.key instanceof ModLockKey) {
+                        if (key.getNotFuzzy().equals(other.key.getNotFuzzy())) {
+                            if (key.fuzzyEquals(other.key)) {
+                                return RequirementComparision.GREATER_THAN;
+                            } else if (other.key.fuzzyEquals(key)) {
+                                return RequirementComparision.LESS_THAN;
+                            }
+                        }
+                    } else if (other.key instanceof GenericNBTLockKey && key.fuzzyEquals(other.key)) {
+                        //If key has all the nbt that other has in addition to being more restrictive
+                        //Does not need to check for LESS_THAN because we are at an mod level lock compared to a general lock
+                        return RequirementComparision.GREATER_THAN;
+                    }
+                } else if (key instanceof GenericNBTLockKey) {
+                    if (other.key instanceof GenericNBTLockKey && key.fuzzyEquals(other.key)) {
+                        //If the other one is generic there is a chance our current one is more restrictive
+                        return RequirementComparision.GREATER_THAN;
+                    } else if (other.key.fuzzyEquals(key)) {
+                        //Generic see if there is a more restrictive requirement in the other one
+                        return RequirementComparision.LESS_THAN;
+                    }
+                }
+            }
+        }
+        return RequirementComparision.NOT_EQUAL;
     }
 
-    private boolean checkHolding(ItemStack stack, EntityPlayer player){
-        return player.getHeldItemMainhand() == stack || player.getHeldItemOffhand() == stack;
-    }
-
-    private ItemStack getStack() {
-        return stack;
+    private boolean itemMatches(ItemStack stack) {
+        if (stack.isEmpty()) {
+            return false;
+        }
+        NBTLockKey fullKey = null;
+        if (key instanceof ItemInfo) {
+            fullKey = new ItemInfo(stack);
+        } else if (key instanceof ModLockKey) {
+            fullKey = new ModLockKey(stack);
+        } else if (key instanceof GenericNBTLockKey) {
+            fullKey = new GenericNBTLockKey(stack);
+        }
+        if (fullKey != null) {
+            //Needs to make sure the base keys are the same
+            LockKey notFuzzy = key.getNotFuzzy();
+            LockKey fullNotFuzzy = fullKey.getNotFuzzy();
+            if (notFuzzy == null) {
+                return fullNotFuzzy == null && fullKey.fuzzyEquals(key);
+            }
+            return notFuzzy.equals(fullNotFuzzy) && fullKey.fuzzyEquals(key);
+        }
+        return false;
     }
 }

--- a/src/main/resources/assets/compatskills/lang/en_us.lang
+++ b/src/main/resources/assets/compatskills/lang/en_us.lang
@@ -4,6 +4,7 @@ compatskills.misc.gamestageFormat=GameStage: %s%s
 
 ## Minecraft
 compatskills.misc.dimensionFormat=Dimension: %s%s
+compatskills.misc.requirements.itemRequirementFormat=Item: %s%s
 
 ## Inverted Requirements
 compatskills.misc.requirements.invertedAchievementFormat=!Advancement: %s


### PR DESCRIPTION
(modid, empty, or modid:item:optional metadata)|nbt as json

Examples I used to test:

```
addRequirement(<minecraft:diamond_sword:*>, "stack|minecraft:iron_sword:*|{ench:[{id: 17s}]}");
addRequirement(<minecraft:diamond_pickaxe:*>, "stack|minecraft:iron_pickaxe:*");
addRequirement(<minecraft:diamond_axe:*>, "stack|minecraft"); //Always true when using because the axe is from minecraft
addRequirement(<minecraft:diamond_shovel:*>, "stack||{ench:[{id: 33s}]}"); //Needs a silk touch item in hand can be offhand
addRequirement(<minecraft:diamond_hoe:*>, "stack|tconstruct|{ench:[{id: 35s}]}");//fortune tinkers tool
```

Closes #41 