### PR TITLE
 Ore dictionary locking and requirements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ dependencies {
     deobfCompile "CraftTweaker2:CraftTweaker2-MC1120-Main:1.12-${crafttweaker_version}"
     deobfCompile "CraftTweaker2:CraftTweaker2-API:1.12-${crafttweaker_version}"
     deobfCompile "CraftTweaker2:ZenScript:1.12-${crafttweaker_version}"
-    deobfCompile "codersafterdark.reskillable:Reskillable:1.12.2-1.4.0-PR-97.1"
+    deobfCompile "codersafterdark.reskillable:Reskillable:1.12.2-1.6.0-PR-106.1"
     deobfCompile "com.wayoftime.bloodmagic:BloodMagic:1.12.2-2.2.11-96"
     deobfCompile "com.azanor.baubles:Baubles:1.12-1.5.2"
     deobfCompile "mcjty.theoneprobe:TheOneProbe-1.12:1.12-1.4.22-13"

--- a/src/main/java/codersafterdark/compatskills/common/compats/minecraft/dimension/dimensionlocks/DimensionLockHandler.java
+++ b/src/main/java/codersafterdark/compatskills/common/compats/minecraft/dimension/dimensionlocks/DimensionLockHandler.java
@@ -25,9 +25,8 @@ public class DimensionLockHandler {
         for (int i = 0; i < player.inventory.armorInventory.size(); i++) {
             ItemStack stack = player.inventory.armorInventory.get(i);
             if (!LevelLockHandler.canPlayerUseItem(player, stack)) {
-                ItemStack copy = stack.copy();
-                if (!player.inventory.addItemStackToInventory(copy)) {
-                    player.dropItem(copy, false);
+                if (!player.inventory.addItemStackToInventory(stack)) {
+                    player.dropItem(stack, false);
                 }
                 player.inventory.armorInventory.set(i, ItemStack.EMPTY);
                 LevelLockHandler.tellPlayer(player, stack, MessageLockedItem.MSG_ARMOR_EQUIP_LOCKED);

--- a/src/main/java/codersafterdark/compatskills/common/compats/minecraft/item/OreDictLock.java
+++ b/src/main/java/codersafterdark/compatskills/common/compats/minecraft/item/OreDictLock.java
@@ -1,0 +1,41 @@
+package codersafterdark.compatskills.common.compats.minecraft.item;
+
+import codersafterdark.reskillable.api.data.LockKey;
+import codersafterdark.reskillable.api.data.NBTLockKey;
+import net.minecraft.nbt.NBTTagCompound;
+
+import java.util.Objects;
+
+public class OreDictLock extends NBTLockKey {
+    private String oreDict;
+
+    public OreDictLock(String oreDict) {
+        this(oreDict, null);
+    }
+
+    public OreDictLock(String oreDict, NBTTagCompound tag) {
+        super(tag);
+        this.oreDict = oreDict == null ? "" : oreDict;
+    }
+
+    @Override
+    public LockKey getNotFuzzy() {
+        return isNotFuzzy() ? this : new OreDictLock(oreDict);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (o instanceof OreDictLock && oreDict.equals(((OreDictLock) o).oreDict)) {
+            return getTag() == null ? ((OreDictLock) o).getTag() == null : getTag().equals(((OreDictLock) o).getTag());
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(oreDict, tag);
+    }
+}

--- a/src/main/java/codersafterdark/compatskills/common/compats/minecraft/item/OreDictRequirement.java
+++ b/src/main/java/codersafterdark/compatskills/common/compats/minecraft/item/OreDictRequirement.java
@@ -1,0 +1,67 @@
+package codersafterdark.compatskills.common.compats.minecraft.item;
+
+import codersafterdark.reskillable.api.data.GenericNBTLockKey;
+import codersafterdark.reskillable.api.data.PlayerData;
+import codersafterdark.reskillable.api.requirement.Requirement;
+import codersafterdark.reskillable.api.requirement.RequirementComparision;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.text.TextComponentTranslation;
+import net.minecraft.util.text.TextFormatting;
+import net.minecraftforge.oredict.OreDictionary;
+
+import java.util.Arrays;
+
+public class OreDictRequirement extends Requirement {
+    private NBTTagCompound tag;
+    private String oreDictEntry;
+    private int oreEntry;
+
+    public OreDictRequirement(String oreDictEntry, NBTTagCompound tag) {
+        this.oreDictEntry = oreDictEntry;
+        this.oreEntry = OreDictionary.getOreID(oreDictEntry); //Cache the value
+        this.tag = tag;
+    }
+
+    @Override
+    public boolean achievedByPlayer(EntityPlayer player) {
+        return hasOreDict(player.getHeldItemMainhand()) || hasOreDict(player.getHeldItemOffhand());
+    }
+
+    private boolean hasOreDict(ItemStack stack) {
+        if (stack.isEmpty() || Arrays.stream(OreDictionary.getOreIDs(stack)).noneMatch(oreID -> oreID == oreEntry)) {
+            return false;
+        }
+        return new GenericNBTLockKey(stack.getTagCompound()).fuzzyEquals(new GenericNBTLockKey(tag));
+    }
+
+    @Override
+    public String getToolTip(PlayerData data) {
+        TextFormatting color = data != null && achievedByPlayer(data.playerWR.get()) ? TextFormatting.GREEN : TextFormatting.RED;
+        String name = oreDictEntry;
+        if (tag != null) {
+            name += " With NBT Tag: " + tag;//Maybe format NBT slightly better
+        }
+        return TextFormatting.GRAY + " - " + new TextComponentTranslation("compatskills.misc.requirements.oreDictRequirementFormat", color, name).getUnformattedComponentText();
+    }
+
+    @Override
+    public RequirementComparision matches(Requirement o) {
+        if (o instanceof OreDictRequirement) {
+            OreDictRequirement other = (OreDictRequirement) o;
+            if (oreEntry == other.oreEntry) {
+                GenericNBTLockKey key = new GenericNBTLockKey(tag);
+                GenericNBTLockKey otherKey = new GenericNBTLockKey(other.tag);
+                if (key.fuzzyEquals(otherKey)) {
+                    //If the other one is generic there is a chance our current one is more restrictive
+                    return RequirementComparision.GREATER_THAN;
+                } else if (otherKey.fuzzyEquals(key)) {
+                    //Generic see if there is a more restrictive requirement in the other one
+                    return RequirementComparision.LESS_THAN;
+                }
+            }
+        }
+        return RequirementComparision.NOT_EQUAL;
+    }
+}

--- a/src/main/java/codersafterdark/compatskills/common/compats/minecraft/item/OreDictionaryTweaker.java
+++ b/src/main/java/codersafterdark/compatskills/common/compats/minecraft/item/OreDictionaryTweaker.java
@@ -1,0 +1,80 @@
+package codersafterdark.compatskills.common.compats.minecraft.item;
+
+import codersafterdark.compatskills.CompatSkills;
+import codersafterdark.compatskills.utils.CheckMethods;
+import codersafterdark.reskillable.api.data.RequirementHolder;
+import codersafterdark.reskillable.base.LevelLockHandler;
+import crafttweaker.IAction;
+import crafttweaker.annotations.ZenRegister;
+import crafttweaker.api.data.IData;
+import crafttweaker.api.oredict.IOreDictEntry;
+import crafttweaker.mc1120.data.NBTConverter;
+import net.minecraft.nbt.NBTTagCompound;
+import stanhebben.zenscript.annotations.ZenClass;
+import stanhebben.zenscript.annotations.ZenMethod;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+@ZenClass("mods.compatskills.OreDictLock")
+@ZenRegister
+public class OreDictionaryTweaker {
+    @ZenMethod
+    public static void addOreDictLock(IOreDictEntry entry, String... locked) {
+        CompatSkills.LATE_ADDITIONS.add(new AddOreDict(entry, locked));
+    }
+
+    @ZenMethod
+    public static void addNBTOreDictLock(IOreDictEntry entry, IData tag, String... locked) {
+        CompatSkills.LATE_ADDITIONS.add(new AddOreDictNBT(entry, tag, locked));
+    }
+
+    private static class AddOreDict implements IAction {
+        private final IOreDictEntry entry;
+        private final String[] requirements;
+
+        private AddOreDict(IOreDictEntry entry, String... requirements) {
+            this.entry = entry;
+            this.requirements = requirements;
+        }
+
+        @Override
+        public void apply() {
+            if (CheckMethods.checkIOreDictEntry(entry) & CheckMethods.checkStringArray(requirements)) {
+                LevelLockHandler.addLockByKey(new OreDictLock(entry.getName()), RequirementHolder.fromStringList(requirements));
+            }
+        }
+
+        @Override
+        public String describe() {
+            return "Setting the requirement of Ore Dictionary Entry: " + entry + " to: " +
+                    Arrays.stream(requirements).map(string -> string + ", ").collect(Collectors.joining());
+        }
+    }
+
+    private static class AddOreDictNBT implements IAction {
+        private final IOreDictEntry entry;
+        private final IData data;
+        private final String[] requirements;
+
+        private AddOreDictNBT(IOreDictEntry entry, IData tag, String... locked) {
+            this.entry = entry;
+            this.data = tag;
+            this.requirements = locked;
+        }
+
+        @Override
+        public void apply() {
+            if (CheckMethods.checkIOreDictEntry(entry) & CheckMethods.checkValidNBTTagCompound(data) & CheckMethods.checkStringArray(requirements)) {
+                RequirementHolder holder = RequirementHolder.fromStringList(requirements);
+                LevelLockHandler.addLockByKey(new OreDictLock(entry.getName(), (NBTTagCompound) NBTConverter.from(data)), holder);
+            }
+        }
+
+        @Override
+        public String describe() {
+            return "Adding NBT lock: " + data + " for Ore Dictionary Entry: " + entry + " with Requirements: " +
+                    Arrays.stream(requirements).map(string -> string + ", ").collect(Collectors.joining());
+        }
+    }
+}

--- a/src/main/java/codersafterdark/compatskills/common/compats/minecraft/item/ParentOreDictLock.java
+++ b/src/main/java/codersafterdark/compatskills/common/compats/minecraft/item/ParentOreDictLock.java
@@ -1,0 +1,43 @@
+package codersafterdark.compatskills.common.compats.minecraft.item;
+
+import codersafterdark.reskillable.api.data.ParentLockKey;
+import codersafterdark.reskillable.api.data.RequirementHolder;
+import codersafterdark.reskillable.base.LevelLockHandler;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraftforge.oredict.OreDictionary;
+
+import java.util.ArrayList;
+import java.util.List;
+
+//This lock should never be created directly, but only be used by the automated checking for items so that we can call the getSubRequirements on it
+//The methods for creating it directly are for in case we ever change our mind about this. (Unlikely)
+public class ParentOreDictLock implements ParentLockKey {
+    private NBTTagCompound tag;
+    private int[] oreIDs;
+
+    public ParentOreDictLock(ItemStack stack) {
+        this(OreDictionary.getOreIDs(stack), stack.getTagCompound());
+    }
+
+    public ParentOreDictLock(int[] oreIDs) {
+        this(oreIDs, null);
+    }
+
+    public ParentOreDictLock(int[] oreIDs, NBTTagCompound tag) {
+        this.oreIDs = oreIDs;
+        this.tag = tag;
+    }
+
+    @Override
+    public RequirementHolder getSubRequirements() {
+        List<RequirementHolder> holders = new ArrayList<>();
+        for (int id : oreIDs) {
+            RequirementHolder holder = LevelLockHandler.getLockByFuzzyKey(new OreDictLock(OreDictionary.getOreName(id), tag));
+            if (!holder.equals(LevelLockHandler.EMPTY_LOCK)) {
+                holders.add(holder);
+            }
+        }
+        return holders.isEmpty() ? LevelLockHandler.EMPTY_LOCK : new RequirementHolder(holders.toArray(new RequirementHolder[0]));
+    }
+}

--- a/src/main/java/codersafterdark/compatskills/common/compats/tinkersconstruct/TinkersCompatHandler.java
+++ b/src/main/java/codersafterdark/compatskills/common/compats/tinkersconstruct/TinkersCompatHandler.java
@@ -2,16 +2,19 @@ package codersafterdark.compatskills.common.compats.tinkersconstruct;
 
 import codersafterdark.compatskills.common.compats.tinkersconstruct.commands.MaterialDumpCommand;
 import codersafterdark.compatskills.common.compats.tinkersconstruct.commands.ModifierDumpCommand;
+import codersafterdark.compatskills.common.compats.tinkersconstruct.materiallocks.MaterialLockKey;
 import codersafterdark.compatskills.common.compats.tinkersconstruct.modifierlocks.ModifierLockKey;
 import codersafterdark.reskillable.base.LevelLockHandler;
 import crafttweaker.mc1120.commands.CTChatCommand;
 import net.minecraftforge.common.MinecraftForge;
+import slimeknights.tconstruct.library.materials.Material;
 import slimeknights.tconstruct.library.modifiers.IToolMod;
 
 public class TinkersCompatHandler {
     private static TinkerLockHandler tinkerLockHandler;
 
     public static void setup() {
+        LevelLockHandler.registerLockKey(Material.class, MaterialLockKey.class);
         LevelLockHandler.registerLockKey(IToolMod.class, ModifierLockKey.class);
         MinecraftForge.EVENT_BUS.register(tinkerLockHandler = new TinkerLockHandler());
     }

--- a/src/main/java/codersafterdark/compatskills/common/compats/tinkersconstruct/materiallocks/MaterialLockKey.java
+++ b/src/main/java/codersafterdark/compatskills/common/compats/tinkersconstruct/materiallocks/MaterialLockKey.java
@@ -1,9 +1,12 @@
 package codersafterdark.compatskills.common.compats.tinkersconstruct.materiallocks;
 
-import codersafterdark.reskillable.api.data.LockKey;
+import codersafterdark.reskillable.api.data.ParentLockKey;
+import codersafterdark.reskillable.api.data.RequirementHolder;
+import codersafterdark.reskillable.base.LevelLockHandler;
 import slimeknights.tconstruct.library.materials.Material;
+import slimeknights.tconstruct.library.modifiers.IToolMod;
 
-public class MaterialLockKey implements LockKey {
+public class MaterialLockKey implements ParentLockKey {
     private final Material material;
 
     public MaterialLockKey(Material material) {
@@ -25,5 +28,10 @@ public class MaterialLockKey implements LockKey {
     @Override
     public int hashCode() {
         return material == null ? super.hashCode() : material.hashCode();
+    }
+
+    @Override
+    public RequirementHolder getSubRequirements() {
+        return LevelLockHandler.getLocks(IToolMod.class, material.getDefaultTraits().toArray(new IToolMod[0]));
     }
 }

--- a/src/main/java/codersafterdark/compatskills/utils/CheckMethods.java
+++ b/src/main/java/codersafterdark/compatskills/utils/CheckMethods.java
@@ -11,10 +11,12 @@ import crafttweaker.api.data.DataMap;
 import crafttweaker.api.data.IData;
 import crafttweaker.api.entity.IEntityDefinition;
 import crafttweaker.api.item.IItemStack;
+import crafttweaker.api.oredict.IOreDictEntry;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.DimensionManager;
 import net.minecraftforge.fml.common.Loader;
+import net.minecraftforge.oredict.OreDictionary;
 import slimeknights.tconstruct.library.TinkerRegistry;
 import slimeknights.tconstruct.library.materials.Material;
 import slimeknights.tconstruct.library.modifiers.IModifier;
@@ -121,6 +123,15 @@ public class CheckMethods {
         }
         return true;
     }
+
+    public static boolean checkIOreDictEntry(IOreDictEntry entry) {
+        if (entry == null || !OreDictionary.doesOreNameExist(entry.getName())) {
+            CraftTweakerAPI.logError("Ore Dictionary Entry: " + entry + " was found to be either null or does not exist!");
+            return false;
+        }
+        return true;
+    }
+
 
     /////////////////
     // Blood Magic //


### PR DESCRIPTION
Examples from when I was testing.
```
import mods.compatskills.Requirement.addRequirement;
mods.compatskills.OreDictLock.addOreDictLock(<ore:ingotIron>, "reskillable:building|15");
mods.compatskills.OreDictLock.addNBTOreDictLock(<ore:ingotGold>, {ench:[{lvl:1 as short, id: 17 as short}]}, "reskillable:building|17");
addRequirement(<minecraft:diamond_pickaxe:*>, "ore|ingotIron");
addRequirement(<minecraft:diamond_axe:*>, "ore|ingotGold|{ench:[{lvl:1s, id: 17s}]}");
```
Note: I was lazy so used default ore dictionary values rather than adding ones for tools where they can actually get enchantments.

I also switched tinker construct compat to using the new ParentLockKey system to make the code a little cleaner and to test the locking.

Tinkers compat now requires https://github.com/Coders-After-Dark/Reskillable/pull/106 as does the new Ore Dictionary locking.