### PR TITLE
Fixes dimension requirements not being registered

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs=-Xmx6G
 
 # Project
 modGroup=codersafterdark.compatskills
-modVersion=1.12.2-1.7.0
+modVersion=1.12.2-1.7.1
 modBaseName=CompatSkills
 
 # MC/Forge/MCP

--- a/src/main/java/codersafterdark/compatskills/common/compats/minecraft/MinecraftCompatHandler.java
+++ b/src/main/java/codersafterdark/compatskills/common/compats/minecraft/MinecraftCompatHandler.java
@@ -1,6 +1,7 @@
 package codersafterdark.compatskills.common.compats.minecraft;
 
 import codersafterdark.compatskills.common.compats.minecraft.dimension.dimensionlocks.DimensionLockHandler;
+import codersafterdark.compatskills.common.compats.minecraft.dimension.dimensionrequirement.DimensionRequirement;
 import codersafterdark.compatskills.common.compats.minecraft.entity.animaltameevent.AnimalTameEventHandler;
 import codersafterdark.compatskills.common.compats.minecraft.entity.entitydamageevent.EntityDamageEventHandler;
 import codersafterdark.compatskills.common.compats.minecraft.entity.entitymountevent.EntityMountEventHandler;
@@ -40,6 +41,13 @@ public class MinecraftCompatHandler {
         MinecraftForge.EVENT_BUS.register(tileEntityHandler);
         MinecraftForge.EVENT_BUS.register(entityDamageHandler);
         RequirementRegistry registry = ReskillableAPI.getInstance().getRequirementRegistry();
+        registry.addRequirementHandler("dim", input -> {
+            try {
+                return new DimensionRequirement(Integer.parseInt(input));
+            } catch (NumberFormatException ignored) {
+            }
+            return null;
+        });
         registry.addRequirementHandler("!dim", input -> registry.getRequirement("not|dim|" + input));
         registry.addRequirementHandler("ore", input -> {
             if (input == null) {

--- a/src/main/java/codersafterdark/compatskills/utils/CompatSkillConstants.java
+++ b/src/main/java/codersafterdark/compatskills/utils/CompatSkillConstants.java
@@ -3,7 +3,7 @@ package codersafterdark.compatskills.utils;
 public class CompatSkillConstants {
     public static final String MOD_ID = "compatskills";
     public static final String MOD_NAME = "CompatSkills";
-    public static final String VERSION = "1.12.2-1.7.0";
+    public static final String VERSION = "1.12.2-1.7.1";
     public static final String DEPENDENCIES = "required-after:reskillable";
     public static final String MCVER = "1.12,";
 

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -3,7 +3,7 @@
   "modid": "compatskills",
   "name": "CompatSkills",
   "description": "CompatSkills is the official compatibility add-on for Reskillable.",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "mcversion": "1.12.2",
   "url": "https://minecraft.curseforge.com/projects/compatskills",
   "authorList": ["Lanse505"],


### PR DESCRIPTION
I by mistake removed its registration when I moved inverted dimension requirements to being a wrapper, and somehow did not notice.