### PR TITLE
Harvest level locking

### DIFF
--- a/src/main/java/codersafterdark/compatskills/common/compats/minecraft/MinecraftCompatHandler.java
+++ b/src/main/java/codersafterdark/compatskills/common/compats/minecraft/MinecraftCompatHandler.java
@@ -8,6 +8,9 @@ import codersafterdark.compatskills.common.compats.minecraft.entity.entitymounte
 import codersafterdark.compatskills.common.compats.minecraft.item.ItemRequirement;
 import codersafterdark.compatskills.common.compats.minecraft.item.OreDictRequirement;
 import codersafterdark.compatskills.common.compats.minecraft.item.ParentOreDictLock;
+import codersafterdark.compatskills.common.compats.minecraft.item.harvestlevel.BlockHarvestLock;
+import codersafterdark.compatskills.common.compats.minecraft.item.harvestlevel.HarvestLevelRequirement;
+import codersafterdark.compatskills.common.compats.minecraft.item.harvestlevel.ToolHarvestLock;
 import codersafterdark.compatskills.common.compats.minecraft.tileentity.TileEntityCommand;
 import codersafterdark.compatskills.common.compats.minecraft.tileentity.TileEntityEventHandler;
 import codersafterdark.reskillable.api.ReskillableAPI;
@@ -28,7 +31,8 @@ import net.minecraftforge.oredict.OreDictionary;
 
 public class MinecraftCompatHandler {
     public static void setup() {
-        LevelLockHandler.registerLockKey(ItemStack.class, ParentOreDictLock.class);
+        //TODO: Maybe only register ones if at least one has been added via a script. This may not be a good idea if our config rewrite ends up supporting custom locks in it
+        LevelLockHandler.registerLockKey(ItemStack.class, ParentOreDictLock.class, ToolHarvestLock.class, BlockHarvestLock.class);
 
         MinecraftForge.EVENT_BUS.register(new AnimalTameEventHandler());
         MinecraftForge.EVENT_BUS.register(new EntityMountEventHandler());
@@ -36,6 +40,13 @@ public class MinecraftCompatHandler {
         MinecraftForge.EVENT_BUS.register(new TileEntityEventHandler());
         MinecraftForge.EVENT_BUS.register(new EntityDamageEventHandler());
         RequirementRegistry registry = ReskillableAPI.getInstance().getRequirementRegistry();
+        registry.addRequirementHandler("harvest", input -> {
+            try {
+                return new HarvestLevelRequirement(Integer.parseInt(input));
+            } catch (NumberFormatException ignored) {
+            }
+            return null;
+        });
         registry.addRequirementHandler("dim", input -> {
             try {
                 return new DimensionRequirement(Integer.parseInt(input));

--- a/src/main/java/codersafterdark/compatskills/common/compats/minecraft/item/harvestlevel/BlockHarvestLock.java
+++ b/src/main/java/codersafterdark/compatskills/common/compats/minecraft/item/harvestlevel/BlockHarvestLock.java
@@ -1,0 +1,47 @@
+package codersafterdark.compatskills.common.compats.minecraft.item.harvestlevel;
+
+import codersafterdark.reskillable.api.data.FuzzyLockKey;
+import codersafterdark.reskillable.api.data.LockKey;
+import net.minecraft.block.Block;
+import net.minecraft.init.Blocks;
+import net.minecraft.item.ItemStack;
+
+import java.util.Objects;
+
+public class BlockHarvestLock implements FuzzyLockKey {
+    private final int harvestLevel;
+
+    public BlockHarvestLock(int harvestLevel) {
+        this.harvestLevel = harvestLevel;
+    }
+
+    public BlockHarvestLock(ItemStack stack) {
+        Block block = Block.getBlockFromItem(stack.getItem());
+        this.harvestLevel = block == Blocks.AIR ? 0 : block.getHarvestLevel(block.getDefaultState());
+    }
+
+    @Override
+    public boolean fuzzyEquals(FuzzyLockKey o) {
+        return o == this || o instanceof BlockHarvestLock && harvestLevel >= ((BlockHarvestLock) o).harvestLevel;
+    }
+
+    @Override
+    public boolean isNotFuzzy() {
+        return false;
+    }
+
+    @Override
+    public LockKey getNotFuzzy() {
+        return null;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return o == this || o instanceof BlockHarvestLock && harvestLevel == ((BlockHarvestLock) o).harvestLevel;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(harvestLevel);
+    }
+}

--- a/src/main/java/codersafterdark/compatskills/common/compats/minecraft/item/harvestlevel/HarvestLevelRequirement.java
+++ b/src/main/java/codersafterdark/compatskills/common/compats/minecraft/item/harvestlevel/HarvestLevelRequirement.java
@@ -1,0 +1,49 @@
+package codersafterdark.compatskills.common.compats.minecraft.item.harvestlevel;
+
+import codersafterdark.reskillable.api.data.PlayerData;
+import codersafterdark.reskillable.api.requirement.Requirement;
+import codersafterdark.reskillable.api.requirement.RequirementComparision;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.text.TextComponentTranslation;
+import net.minecraft.util.text.TextFormatting;
+
+public class HarvestLevelRequirement extends Requirement {
+    private final int harvestLevel;
+
+    public HarvestLevelRequirement(int level) {
+        this.harvestLevel = level;
+    }
+
+    @Override
+    public boolean achievedByPlayer(EntityPlayer player) {
+        return hasHarvestLevel(player.getHeldItemMainhand()) || hasHarvestLevel(player.getHeldItemOffhand());
+    }
+
+    @Override
+    public String getToolTip(PlayerData data) {
+        TextFormatting color = data == null || !achievedByPlayer(data.playerWR.get()) ? TextFormatting.RED : TextFormatting.GREEN;
+        return TextFormatting.GRAY + " - " + new TextComponentTranslation("compatskills.misc.requirements.harvestLevelRequirementFormat", color, harvestLevel).getUnformattedComponentText();
+    }
+
+    @Override
+    public RequirementComparision matches(Requirement o) {
+        if (o instanceof HarvestLevelRequirement) {
+            HarvestLevelRequirement other = (HarvestLevelRequirement) o;
+            if (harvestLevel == other.harvestLevel) {
+                return RequirementComparision.EQUAL_TO;
+            }
+            return harvestLevel > other.harvestLevel ? RequirementComparision.GREATER_THAN : RequirementComparision.LESS_THAN;
+        }
+        return RequirementComparision.NOT_EQUAL;
+    }
+
+    private boolean hasHarvestLevel(ItemStack stack) {
+        if (stack.isEmpty()) {
+            return false;
+        }
+        Item item = stack.getItem();
+        return item.getToolClasses(stack).stream().anyMatch(toolClass -> item.getHarvestLevel(stack, toolClass, null, null) >= harvestLevel);
+    }
+}

--- a/src/main/java/codersafterdark/compatskills/common/compats/minecraft/item/harvestlevel/HarvestLevelTweaker.java
+++ b/src/main/java/codersafterdark/compatskills/common/compats/minecraft/item/harvestlevel/HarvestLevelTweaker.java
@@ -1,0 +1,73 @@
+package codersafterdark.compatskills.common.compats.minecraft.item.harvestlevel;
+
+import codersafterdark.compatskills.CompatSkills;
+import codersafterdark.compatskills.utils.CheckMethods;
+import codersafterdark.reskillable.api.data.RequirementHolder;
+import codersafterdark.reskillable.base.LevelLockHandler;
+import crafttweaker.IAction;
+import crafttweaker.annotations.ZenRegister;
+import stanhebben.zenscript.annotations.ZenClass;
+import stanhebben.zenscript.annotations.ZenMethod;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+@ZenClass("mods.compatskills.HarvestLock")
+@ZenRegister
+public class HarvestLevelTweaker {
+    @ZenMethod
+    public static void addToolLevelLock(int level, String... requirements) {
+        CompatSkills.LATE_ADDITIONS.add(new AddToolLevelLock(level, requirements));
+    }
+
+    @ZenMethod
+    public static void addBlockLevelLock(int level, String... requirements) {
+        CompatSkills.LATE_ADDITIONS.add(new AddBlockLevelLock(level, requirements));
+    }
+
+    private static class AddToolLevelLock implements IAction {
+        private final int harvestLevel;
+        private final String[] requirements;
+
+        private AddToolLevelLock(int harvestLevel, String... requirements) {
+            this.harvestLevel = harvestLevel;
+            this.requirements = requirements;
+        }
+
+        @Override
+        public void apply() {
+            if (CheckMethods.checkInt(harvestLevel) & CheckMethods.checkStringArray(requirements)) {
+                LevelLockHandler.addLockByKey(new ToolHarvestLock(harvestLevel), RequirementHolder.fromStringList(requirements));
+            }
+        }
+
+        @Override
+        public String describe() {
+            String descString = Arrays.stream(requirements).map(string -> string + ", ").collect(Collectors.joining());
+            return "Added Harvest Level Lock for tools with harvest level: " + harvestLevel + ", With Requirements: " + descString;
+        }
+    }
+
+    private static class AddBlockLevelLock implements IAction {
+        private final int harvestLevel;
+        private final String[] requirements;
+
+        private AddBlockLevelLock(int harvestLevel, String... requirements) {
+            this.harvestLevel = harvestLevel;
+            this.requirements = requirements;
+        }
+
+        @Override
+        public void apply() {
+            if (CheckMethods.checkInt(harvestLevel) & CheckMethods.checkStringArray(requirements)) {
+                LevelLockHandler.addLockByKey(new BlockHarvestLock(harvestLevel), RequirementHolder.fromStringList(requirements));
+            }
+        }
+
+        @Override
+        public String describe() {
+            String descString = Arrays.stream(requirements).map(string -> string + ", ").collect(Collectors.joining());
+            return "Added Harvest Level Lock for blocks of harvest level: " + harvestLevel + ", With Requirements: " + descString;
+        }
+    }
+}

--- a/src/main/java/codersafterdark/compatskills/common/compats/minecraft/item/harvestlevel/ToolHarvestLock.java
+++ b/src/main/java/codersafterdark/compatskills/common/compats/minecraft/item/harvestlevel/ToolHarvestLock.java
@@ -1,0 +1,57 @@
+package codersafterdark.compatskills.common.compats.minecraft.item.harvestlevel;
+
+import codersafterdark.reskillable.api.data.FuzzyLockKey;
+import codersafterdark.reskillable.api.data.LockKey;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+
+import java.util.Objects;
+
+public class ToolHarvestLock implements FuzzyLockKey {
+    private final int harvestLevel;
+
+    public ToolHarvestLock(int harvestLevel) {
+        this.harvestLevel = harvestLevel;
+    }
+
+    public ToolHarvestLock(ItemStack stack) {
+        if (stack.isEmpty()) {
+            this.harvestLevel = 0;
+            return;
+        }
+        int highestLevel = 0;
+        Item item = stack.getItem();
+        for (String toolClass : item.getToolClasses(stack)) {
+            int level = item.getHarvestLevel(stack, toolClass, null, null);
+            if (level > highestLevel) {
+                highestLevel = level;
+            }
+        }
+        this.harvestLevel = highestLevel;
+    }
+
+    @Override
+    public boolean fuzzyEquals(FuzzyLockKey o) {
+        return o == this || o instanceof ToolHarvestLock && harvestLevel >= ((ToolHarvestLock) o).harvestLevel;
+    }
+
+    @Override
+    public boolean isNotFuzzy() {
+        return false;
+    }
+
+    @Override
+    public LockKey getNotFuzzy() {
+        return null;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return o == this || o instanceof ToolHarvestLock && harvestLevel == ((ToolHarvestLock) o).harvestLevel;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(harvestLevel);
+    }
+}

--- a/src/main/resources/assets/compatskills/lang/en_us.lang
+++ b/src/main/resources/assets/compatskills/lang/en_us.lang
@@ -8,13 +8,7 @@ compatskills.misc.requirements.itemRequirementFormat=Item: %s%s
 
 ## Forge
 compatskills.misc.requirements.oreDictRequirementFormat=Ore Dictionary Entry: %s%s
-
-## Inverted Requirements
-compatskills.misc.requirements.invertedAchievementFormat=!Advancement: %s
-compatskills.misc.requirements.invertedSkillFormat=!%s%s: %s%d
-compatskills.misc.requirements.invertedTraitFormat=!Trait: %s%s
-compatskills.misc.requirements.invertedGamestageFormat=!GameStage: %s%s
-compatskills.misc.requirements.invertedDimensionFormat=!Dimension: %s%s
+compatskills.misc.requirements.harvestLevelRequirementFormat=Harvest Level: %s%s
 
 
 # Error Messages

--- a/src/main/resources/assets/compatskills/lang/ru_RU.lang
+++ b/src/main/resources/assets/compatskills/lang/ru_RU.lang
@@ -9,13 +9,6 @@ compatskills.misc.requirements.itemRequirementFormat=Item: %s%s
 ## Forge
 compatskills.misc.requirements.oreDictRequirementFormat=Ore Dictionary Entry: %s%s
 
-## Inverted Requirements
-compatskills.misc.requirements.invertedAchievementFormat=!Достижение: %s
-compatskills.misc.requirements.invertedSkillFormat=!%s%s: %s%d
-compatskills.misc.requirements.invertedTraitFormat=!Награда: %s%s
-compatskills.misc.requirements.invertedGamestageFormat=!Стадия: %s%s
-compatskills.misc.requirements.invertedDimensionFormat=!Измерение: %s%s
-
 
 # Error Messages
 ## Game Stages

--- a/src/main/resources/assets/compatskills/lang/zh_cn.lang
+++ b/src/main/resources/assets/compatskills/lang/zh_cn.lang
@@ -3,11 +3,6 @@ compatskills.misc.gamestageFormat=游戏阶段： %s%s
 compatskills.misc.Requirements=需要：
 compatskills.misc.Shift=按住 Shift 键查看需求
 
-compatskills.misc.requirements.invertedAchievementFormat=!进度： %s
-compatskills.misc.requirements.invertedGamestageFormat=!游戏阶段： %s%s
-compatskills.misc.requirements.invertedSkillFormat=!%s%s: %s%d
-compatskills.misc.requirements.invertedTraitFormat=!特性： %s%s
-
 compatskills.gamestage.addError=未满足解锁这个阶段的要求！
 
 compatskills.reskillable.addLevelLockError=要达到这个等级：


### PR DESCRIPTION
- Allows locking blocks by their required harvest level
- Allows locking tools by their harvest level
- Requirement to require holding a tool with a specific harvest level

Examples from when I was testing things:
```
mods.compatskills.HarvestLock.addToolLevelLock(1, "reskillable:mining|3");
mods.compatskills.HarvestLock.addBlockLevelLock(2, "reskillable:mining|7");

addRequirement(<minecraft:redstone>, "harvest|3");
```

All harvest locks are >= the given level.

Also removes inverted requirement formats from lang files as the strings do not get used anymore.